### PR TITLE
Corrected README.md  pip installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Installation
 This plugin can be installed via pip:
 ```
-$ pip install dbt-spark
+$ pip install dbt[spark]
 ```
 
 ### Configuring your profile


### PR DESCRIPTION
should be pip install dbt[spark]